### PR TITLE
Use -dev tag

### DIFF
--- a/kube/deploy.yaml
+++ b/kube/deploy.yaml
@@ -14,7 +14,7 @@ spec:
         app: rhys-oomps
     spec:
       containers:
-      - image: rhysemmas/oomps:3.0 # 2gb allocator
+      - image: rhysemmas/oomps:3.0-dev # 2gb allocator
         imagePullPolicy: Always
         name: oomps
         resources:


### PR DESCRIPTION
Use the `-dev` tag for the `3.0` image which is reserved for the 2gb allocation version of the app - the `3.0` tag is currently the same, but this is more explicit/will remind me