### PR TITLE
4.0 and 4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /bin
 test*
 *.test
+live-*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # OOMps
 
 Silly memory allocation in C++ to test the behaviour of VPA running in kube.
+
+The main flaw with this application is that it does not account for the amount of memory consumed by the array of pointers it keeps for every allocated 4k block.
+
+A pointer will consume 8 bytes of memory (64-bit) so the number of chunks allocated needs to be multiplied by 8 bytes in order to get the overhead memory footprint for keeping this array of pointers.
+
+As this app is intended to test the behaviour of VPA, I have not addressed this issue. Setting the number of chunks to what I expect to see for xGB memory usage and the initial limits for the pod to be the same is fine in my case, as VPA will end up scaling the memory limits accordingly during my testing - even if it means the container will be OOMKilled until VPA scales its limits up.

--- a/kube/deploy.yaml
+++ b/kube/deploy.yaml
@@ -14,7 +14,7 @@ spec:
         app: rhys-oomps
     spec:
       containers:
-      - image: rhysemmas/oomps:4.0-dev # 2gb allocator
+      - image: rhysemmas/oomps:4.1-dev # 2gb allocator
         imagePullPolicy: Always
         name: oomps
         resources:

--- a/kube/deploy.yaml
+++ b/kube/deploy.yaml
@@ -14,9 +14,13 @@ spec:
         app: rhys-oomps
     spec:
       containers:
-      - image: rhysemmas/oomps:3.0-dev # 2gb allocator
+      - image: rhysemmas/oomps:4.0-dev # 2gb allocator
         imagePullPolicy: Always
         name: oomps
         resources:
           requests:
             memory: "1Gi"
+            cpu: "500m"
+          limits:
+            memory: "2Gi"
+            cpu: "800m"

--- a/kube/vpa.yaml
+++ b/kube/vpa.yaml
@@ -9,11 +9,6 @@ spec:
   updatePolicy:
     updateMode: "Auto"
   targetRef:
-    apiVersion: "apps/v1"
+    apiVersion: apps/v1
     kind: Deployment
     name: rhys-oomps
-  # resourcePolicy:
-  #   containerPolicies:
-  #   - containerName: '*'
-  #     minAllowed:
-  #       memory: 25Mi

--- a/main.cpp
+++ b/main.cpp
@@ -16,7 +16,10 @@ using namespace std;
 int main()
 {
   int n = NUM_CHUNKS;
-  void * ptr[NUM_CHUNKS];
+  // allocate on the heap - very large arrays will not fit on the stack
+  // the line commented out below will be ok for the 2gb example
+  //void * ptr[NUM_CHUNKS];
+  void **ptr = new void*[NUM_CHUNKS];
 
   for (int i = 0; i < n; i++)
   // with i being less than n, we should be short 1 * 4k block

--- a/main.cpp
+++ b/main.cpp
@@ -3,20 +3,28 @@
 #include <cstring>
 
 #define CHUNK_SIZE 4096
-#define NUM_CHUNKS 29884416
-// 4096 * 29884416 = 122406567936 bytes (114GB)
+#define NUM_CHUNKS 26214400 // 100gb
 //#define NUM_CHUNKS 524288 // 2gb
+
+// CHUNK_SIZE * NUM_CHUNKS = memory usage (bytes)
+// e.g: 4096 * 29884416 = 122406567936 bytes (114GB)
+// array of pointers will use NUM_CHUNKS * 8 bytes (64 bit)
+// 2gb memory usage with 4k blocks = 4mb of memory usage for array of pointers
 
 using namespace std;
 
 int main()
 {
   int n = NUM_CHUNKS;
+  void * ptr[NUM_CHUNKS];
+
   for (int i = 0; i < n; i++)
   // with i being less than n, we should be short 1 * 4k block
   {
-    void* ptr = malloc(CHUNK_SIZE);
-    if (ptr == nullptr)
+    ptr[i] = malloc(CHUNK_SIZE);
+    // malloc returns a pointer to the start of a the block
+    cout << "Start of block: " << ptr[i] << endl;
+    if (ptr[i] == nullptr)
     {
       // allocation failed, we will probably get OOMed before ever seeing this
       cout << "Oh dear" << endl;
@@ -24,7 +32,7 @@ int main()
     else
     {
       // memory allocated, set memory chunk to zero's
-      cout << "Allocated block" << endl;
+      cout << "Initialising allocated block" << endl;
       memset(ptr, 0, CHUNK_SIZE);
 
       if (i == n - 1)


### PR DESCRIPTION
Creates an array of pointers for the chunks in order to stop clever OS's from cleaning up unused memory

Allocates this array to the heap, as in cases where we have a large number of chunks, there's not enough memory on the stack to fit the array